### PR TITLE
Update main.tf

### DIFF
--- a/Sec02/Lab_2.1/main.tf
+++ b/Sec02/Lab_2.1/main.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version = "~> 2.18"
   features {}
 }
 


### PR DESCRIPTION
Hi, I'm taking your course and came across this warning below. This line has to be removed as per this information (https://itnext.io/upgrading-to-terraform-0-14-experience-warning-18ea3f4bc396), I have tested it and it works fine, hope you don't mind me pointing this out in your code, cheers.

Warning: Version constraints inside provider configuration blocks are deprecated

  on main.tf line 2, in provider "azurerm":
   2:   version = "~> 2.18"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.